### PR TITLE
0.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ or manually using this URL:
 	
 # Changelog
 
+## [0.2.1] - 2018-11-17
+### Added
+- New `Include Trailing Character` setting to account for some firmware that clips the last character of M117 commands (i.e. ANET E10).
+
 ## [0.2.0] - 2018-05-26
 ### Added
 - New delay option for checking ip and sending to control panel to resolve cold start issues.
@@ -31,6 +35,7 @@ I programmed this plugin for fun and do my best effort to support those that hav
 
 [![paypal](https://www.paypalobjects.com/en_US/i/btn/btn_donateCC_LG.gif)](https://paypal.me/jneilliii)
 
+[0.2.1]: https://github.com/jneilliii/OctoPrint-ipOnConnect/tree/0.2.1
 [0.2.0]: https://github.com/jneilliii/OctoPrint-ipOnConnect/tree/0.2.0
 [0.1.0]: https://github.com/jneilliii/OctoPrint-ipOnConnect/tree/0.1.0
 

--- a/octoprint_ipOnConnect/__init__.py
+++ b/octoprint_ipOnConnect/__init__.py
@@ -13,7 +13,7 @@ class ipOnConnectPlugin(octoprint.plugin.SettingsPlugin,
 	##~~ SettingsPlugin mixin
 	
 	def get_settings_defaults(self):
-		return dict(delay=0)
+		return dict(delay=0,addTrailingChar=False)
 						
 	##~~ StartupPlugin mixin
 	
@@ -38,7 +38,10 @@ class ipOnConnectPlugin(octoprint.plugin.SettingsPlugin,
 	def get_ip_and_send(self):
 		server_ip = [(s.connect((self._settings.global_get(["server","onlineCheck","host"]), self._settings.global_get(["server","onlineCheck","port"]))), s.getsockname()[0], s.close()) for s in [socket.socket(socket.AF_INET, socket.SOCK_DGRAM)]][0][1]
 		self._logger.info("ipOnConnectPlugin: " + server_ip)
-		self._printer.commands("M117 " + server_ip)
+		message = "M117 " + server_ip
+		if self._settings.get(["addTrailingChar"]):
+			message += "_"
+		self._printer.commands(message)
 
 	##~~ Softwareupdate hook
 

--- a/octoprint_ipOnConnect/templates/ipOnConnect_settings.jinja2
+++ b/octoprint_ipOnConnect/templates/ipOnConnect_settings.jinja2
@@ -9,4 +9,9 @@
 			</span>
         </div>
     </div>
+	<div class="control-group">
+		<div class="controls">
+			<label class="checkbox"><input type="checkbox" data-bind="checked: settings.plugins.ipOnConnect.addTrailingChar"/> Include Trailing Character</label>
+		</div>
+	</div>
 </form>

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_ipOnConnect"
 plugin_name = "OctoPrint-ipOnConnect"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "0.2.0"
+plugin_version = "0.2.1"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
### Added
- New `Include Trailing Character` setting to account for some firmware that clips the last character of M117 commands (i.e. ANET E10).

Resolves #6.