### PR TITLE
Add option to use M70 for message display.

### DIFF
--- a/octoprint_ipOnConnect/__init__.py
+++ b/octoprint_ipOnConnect/__init__.py
@@ -13,7 +13,7 @@ class ipOnConnectPlugin(octoprint.plugin.SettingsPlugin,
 	##~~ SettingsPlugin mixin
 	
 	def get_settings_defaults(self):
-		return dict(delay=0,addTrailingChar=False)
+		return dict(delay=0,addTrailingChar=False,useM70=0,displayTime="10")
 						
 	##~~ StartupPlugin mixin
 	
@@ -38,9 +38,12 @@ class ipOnConnectPlugin(octoprint.plugin.SettingsPlugin,
 	def get_ip_and_send(self):
 		server_ip = [(s.connect((self._settings.global_get(["server","onlineCheck","host"]), self._settings.global_get(["server","onlineCheck","port"]))), s.getsockname()[0], s.close()) for s in [socket.socket(socket.AF_INET, socket.SOCK_DGRAM)]][0][1]
 		self._logger.info("ipOnConnectPlugin: " + server_ip)
-		message = "M117 " + server_ip
 		if self._settings.get(["addTrailingChar"]):
-			message += "_"
+			server_ip += "_"
+		if self._settings.get(["useM70"]):
+			message = "M70 P" + self._settings.get(["displayTime"]) + " (" + server_ip + ")"
+		else:
+			message = "M117 " + server_ip
 		self._printer.commands(message)
 
 	##~~ Softwareupdate hook

--- a/octoprint_ipOnConnect/templates/ipOnConnect_settings.jinja2
+++ b/octoprint_ipOnConnect/templates/ipOnConnect_settings.jinja2
@@ -14,4 +14,18 @@
 			<label class="checkbox"><input type="checkbox" data-bind="checked: settings.plugins.ipOnConnect.addTrailingChar"/> Include Trailing Character</label>
 		</div>
 	</div>
+	<div class="control-group">
+		<div class="controls">
+			<label class="checkbox"><input type="checkbox" data-bind="checked: settings.plugins.ipOnConnect.useM70"/> Show message using M70</label>
+		</div>
+	</div>
+	<div class="control-group">
+		<label class="control-label" for="ipOnConnectDisplayTime">Display time</label>
+		<div class="controls">
+			<span class="input-append">
+				<input type="number" increment="1" class="input-mini" id="ipOnConnectDisplayTime" data-bind="value: settings.plugins.ipOnConnect.displayTime" />
+				<span class="add-on">sec</span>
+			</span>
+		</div>
+	</div>
 </form>


### PR DESCRIPTION
Hi!
This change allows the plugin to work with the ZYYX line of printers which do not support the M117 command. I guess this may be true for other printers using the Sailfish firmware as well.